### PR TITLE
feat: make staleness check more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "node"
+# nodejs 11.11.X was failing with this https://travis-ci.org/moxystudio/node-proper-lockfile/jobs/503161746#L469
+#   - "node"
   - "lts/*"
 # Report coverage
 after_success:

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -93,17 +93,36 @@ function updateLock(file, options) {
 
     lock.updateDelay = lock.updateDelay || options.update;
     lock.updateTimeout = setTimeout(() => {
-        const mtime = Date.now() / 1000;
+        const mtime = new Date();
 
         lock.updateTimeout = null;
 
-        // Check if mtime is still ours
+        // Check if mtime is still ours if it is we can still recover from a system sleep or a busy event loop
         options.fs.stat(getLockFile(file, options), (err, stat) => {
-            // Check mtime ownership
-            const isMtimeOurs = options.checkMtimeOwnership && lock.stat.mtimeMs === (stat ? stat.mtimeMs : null);
+            const isMtimeOurs = options.checkMtimeOwnership && lock.mtime.getTime() === (stat ? stat.mtime.getTime() : null);
+            const isOverThreshold = lock.lastUpdate + options.stale < Date.now();
 
+            // If it failed to update the lockfile, keep trying unless
+            // the lockfile was deleted or we are over the threshold
             if (err) {
-                // We handle this below
+                if (err.code === 'ENOENT' || isOverThreshold) {
+                    return setLockAsCompromised(file, lock, Object.assign(err, { code: 'ECOMPROMISED' }));
+                }
+
+                lock.updateError = err;
+                lock.updateDelay = 1000;
+
+                return updateLock(file, options);
+            }
+
+            if (!isMtimeOurs) {
+                return setLockAsCompromised(
+                    file,
+                    lock,
+                    Object.assign(
+                        new Error('Unable to update lock within the stale threshold'),
+                        { code: 'ECOMPROMISED' }
+                    ));
             }
 
             options.fs.utimes(getLockFile(file, options), mtime, mtime, (err) => {
@@ -127,17 +146,8 @@ function updateLock(file, options) {
                     return updateLock(file, options);
                 }
 
-                if (isOverThreshold && !isMtimeOurs) {
-                    return setLockAsCompromised(
-                        file,
-                        lock,
-                        Object.assign(
-                            new Error('Unable to update lock within the stale threshold'),
-                            { code: 'ECOMPROMISED' }
-                        ));
-                }
-
                 // All ok, keep updating..
+                lock.mtime = mtime;
                 lock.lastUpdate = Date.now();
                 lock.updateError = null;
                 lock.updateDelay = null;
@@ -220,6 +230,7 @@ function lock(file, options, callback) {
                 // We now own the lock
                 const lock = locks[file] = {
                     stat,
+                    mtime: stat.mtime,
                     options,
                     lastUpdate: Date.now(),
                 };

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -93,13 +93,11 @@ function updateLock(file, options) {
 
     lock.updateDelay = lock.updateDelay || options.update;
     lock.updateTimeout = setTimeout(() => {
-        const mtime = new Date();
-
         lock.updateTimeout = null;
 
         // Check if mtime is still ours if it is we can still recover from a system sleep or a busy event loop
         options.fs.stat(getLockFile(file, options), (err, stat) => {
-            const isMtimeOurs = options.checkMtimeOwnership && lock.mtime.getTime() === (stat ? stat.mtime.getTime() : null);
+            const isMtimeOurs = lock.mtime.getTime() === (stat ? stat.mtime.getTime() : null);
             const isOverThreshold = lock.lastUpdate + options.stale < Date.now();
 
             // If it failed to update the lockfile, keep trying unless
@@ -124,6 +122,8 @@ function updateLock(file, options) {
                         { code: 'ECOMPROMISED' }
                     ));
             }
+
+            const mtime = new Date();
 
             options.fs.utimes(getLockFile(file, options), mtime, mtime, (err) => {
                 const isOverThreshold = lock.lastUpdate + options.stale < Date.now();
@@ -196,7 +196,6 @@ function lock(file, options, callback) {
         update: null,
         realpath: true,
         retries: 0,
-        checkMtimeOwnership: true,
         fs,
         onCompromised: (err) => { throw err; },
         ...options,
@@ -229,7 +228,6 @@ function lock(file, options, callback) {
 
                 // We now own the lock
                 const lock = locks[file] = {
-                    stat,
                     mtime: stat.mtime,
                     options,
                     lastUpdate: Date.now(),

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -26,7 +26,7 @@ function acquireLock(file, options, callback) {
     options.fs.mkdir(getLockFile(file, options), (err) => {
         // If successful, we are done
         if (!err) {
-            return callback();
+            return options.fs.stat(getLockFile(file, options), callback);
         }
 
         // If error is not EEXIST then some other error occurred while locking
@@ -97,43 +97,52 @@ function updateLock(file, options) {
 
         lock.updateTimeout = null;
 
-        options.fs.utimes(getLockFile(file, options), mtime, mtime, (err) => {
-            // Ignore if the lock was released
-            if (lock.released) {
-                return;
-            }
+        // Check if mtime is still ours
+        options.fs.stat(getLockFile(file, options), (err, stat) => {
+            // Check mtime ownership
+            const isMtimeOurs = options.checkMtimeOwnership && lock.stat.mtimeMs === (stat ? stat.mtimeMs : null);
 
-            // Verify if we are within the stale threshold
-            if (lock.lastUpdate <= Date.now() - options.stale && lock.lastUpdate > Date.now() - (options.stale * 2)) {
-                const err = Object.assign(
-                    new Error(lock.updateError || 'Unable to update lock within the stale threshold'),
-                    { code: 'ECOMPROMISED' }
-                );
-
-                return setLockAsCompromised(file, lock, err);
-            }
-
-            // If the file is older than (stale * 2), we assume the clock is moved manually,
-            // which we consider a valid case
-
-            // If it failed to update the lockfile, keep trying unless
-            // the lockfile was deleted!
             if (err) {
-                if (err.code === 'ENOENT') {
-                    return setLockAsCompromised(file, lock, Object.assign(err, { code: 'ECOMPROMISED' }));
+                // We handle this below
+            }
+
+            options.fs.utimes(getLockFile(file, options), mtime, mtime, (err) => {
+                const isOverThreshold = lock.lastUpdate + options.stale < Date.now();
+
+                // Ignore if the lock was released
+                if (lock.released) {
+                    return;
                 }
 
-                lock.updateError = err;
-                lock.updateDelay = 1000;
+                // If it failed to update the lockfile, keep trying unless
+                // the lockfile was deleted or we are over the threshold
+                if (err) {
+                    if (err.code === 'ENOENT' || isOverThreshold) {
+                        return setLockAsCompromised(file, lock, Object.assign(err, { code: 'ECOMPROMISED' }));
+                    }
 
-                return updateLock(file, options);
-            }
+                    lock.updateError = err;
+                    lock.updateDelay = 1000;
 
-            // All ok, keep updating..
-            lock.lastUpdate = Date.now();
-            lock.updateError = null;
-            lock.updateDelay = null;
-            updateLock(file, options);
+                    return updateLock(file, options);
+                }
+
+                if (isOverThreshold && !isMtimeOurs) {
+                    return setLockAsCompromised(
+                        file,
+                        lock,
+                        Object.assign(
+                            new Error('Unable to update lock within the stale threshold'),
+                            { code: 'ECOMPROMISED' }
+                        ));
+                }
+
+                // All ok, keep updating..
+                lock.lastUpdate = Date.now();
+                lock.updateError = null;
+                lock.updateDelay = null;
+                updateLock(file, options);
+            });
         });
     }, lock.updateDelay);
 
@@ -177,6 +186,7 @@ function lock(file, options, callback) {
         update: null,
         realpath: true,
         retries: 0,
+        checkMtimeOwnership: true,
         fs,
         onCompromised: (err) => { throw err; },
         ...options,
@@ -198,7 +208,7 @@ function lock(file, options, callback) {
         const operation = retry.operation(options.retries);
 
         operation.attempt(() => {
-            acquireLock(file, options, (err) => {
+            acquireLock(file, options, (err, stat) => {
                 if (operation.retry(err)) {
                     return;
                 }
@@ -209,6 +219,7 @@ function lock(file, options, callback) {
 
                 // We now own the lock
                 const lock = locks[file] = {
+                    stat,
                     options,
                     lastUpdate: Date.now(),
                 };

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -97,7 +97,6 @@ function updateLock(file, options) {
 
         // Check if mtime is still ours if it is we can still recover from a system sleep or a busy event loop
         options.fs.stat(getLockFile(file, options), (err, stat) => {
-            const isMtimeOurs = lock.mtime.getTime() === (stat ? stat.mtime.getTime() : null);
             const isOverThreshold = lock.lastUpdate + options.stale < Date.now();
 
             // If it failed to update the lockfile, keep trying unless
@@ -107,11 +106,12 @@ function updateLock(file, options) {
                     return setLockAsCompromised(file, lock, Object.assign(err, { code: 'ECOMPROMISED' }));
                 }
 
-                lock.updateError = err;
                 lock.updateDelay = 1000;
 
                 return updateLock(file, options);
             }
+
+            const isMtimeOurs = lock.mtime.getTime() === stat.mtime.getTime();
 
             if (!isMtimeOurs) {
                 return setLockAsCompromised(
@@ -140,7 +140,6 @@ function updateLock(file, options) {
                         return setLockAsCompromised(file, lock, Object.assign(err, { code: 'ECOMPROMISED' }));
                     }
 
-                    lock.updateError = err;
                     lock.updateDelay = 1000;
 
                     return updateLock(file, options);
@@ -149,7 +148,6 @@ function updateLock(file, options) {
                 // All ok, keep updating..
                 lock.mtime = mtime;
                 lock.lastUpdate = Date.now();
-                lock.updateError = null;
                 lock.updateDelay = null;
                 updateLock(file, options);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2911,7 +2911,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -2965,14 +2965,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2987,20 +2985,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3117,8 +3112,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3130,7 +3124,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3145,7 +3138,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3153,14 +3145,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3179,7 +3169,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3260,8 +3249,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3273,7 +3261,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3395,7 +3382,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3523,7 +3509,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -3558,7 +3544,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -3577,7 +3563,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -3624,7 +3610,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -3756,7 +3742,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8473,6 +8473,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thread-sleep": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/thread-sleep/-/thread-sleep-2.1.0.tgz",
+      "integrity": "sha512-VC9Uhr3k2tP/daEKACIamL00ETclXwku39HDHvvgk+pEhi592iLDT7YQUMYLRWCkZcVU1OcsbaoEP7pE/go6YA==",
+      "dev": true
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "p-defer": "^1.0.0",
     "rimraf": "^2.6.2",
     "stable": "^0.1.8",
-    "standard-version": "^4.4.0"
+    "standard-version": "^4.4.0",
+    "thread-sleep": "^2.1.0"
   }
 }

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -2,6 +2,7 @@
 
 const fs = require('graceful-fs');
 const mkdirp = require('mkdirp');
+const sleep = require('thread-sleep');
 const rimraf = require('rimraf');
 const execa = require('execa');
 const pDefer = require('p-defer');
@@ -183,12 +184,16 @@ it('should remove and acquire over stale locks', async () => {
 
 it('should retry if the lockfile was removed when verifying staleness', async () => {
     const mtime = (Date.now() - 60000) / 1000;
+    let count = 0;
     const customFs = {
         ...fs,
         mkdir: jest.fn((...args) => fs.mkdir(...args)),
         stat: jest.fn((...args) => {
-            rimraf.sync(`${tmpDir}/foo.lock`);
+            if (count % 2 === 0) {
+                rimraf.sync(`${tmpDir}/foo.lock`);
+            }
             fs.stat(...args);
+            count += 1;
         }),
     };
 
@@ -199,7 +204,7 @@ it('should retry if the lockfile was removed when verifying staleness', async ()
     await lockfile.lock(`${tmpDir}/foo`, { fs: customFs });
 
     expect(customFs.mkdir).toHaveBeenCalledTimes(2);
-    expect(customFs.stat).toHaveBeenCalledTimes(1);
+    expect(customFs.stat).toHaveBeenCalledTimes(2);
     expect(fs.statSync(`${tmpDir}/foo.lock`).mtime.getTime()).toBeGreaterThan(Date.now() - 3000);
 });
 
@@ -394,7 +399,7 @@ it('should call the compromised function if updating the lockfile took too much 
 
     const handleCompromised = (err) => {
         expect(err.code).toBe('ECOMPROMISED');
-        expect(err.message).toMatch('threshold');
+        expect(err.message).toMatch('foo');
 
         deferred.resolve();
     };
@@ -499,3 +504,45 @@ it('should set update to a maximum of stale / 2', async () => {
 
     expect(fs.statSync(`${tmpDir}/foo.lock`).mtime.getTime()).toBeGreaterThan(mtime);
 }, 10000);
+
+it('should not fail to update mtime when we are over the threshold but mtime is ours, first', async () => {
+    fs.writeFileSync(`${tmpDir}/foo`, '');
+    await lockfile.lock(`${tmpDir}/foo`, { update: 1000, stale: 2000 });
+    sleep(3000);
+    await pDelay(5000);
+}, 16000);
+
+it('should not fail to update mtime when we are over the threshold but mtime is ours, not first', async () => {
+    fs.writeFileSync(`${tmpDir}/foo`, '');
+    await lockfile.lock(`${tmpDir}/foo`, { update: 1000, stale: 2000 });
+    setTimeout(() => {
+        sleep(3000);
+    }, 1000);
+    await pDelay(5000);
+}, 16000);
+
+it('should fail to update mtime when forced over the threshold, first update ', async () => {
+    fs.writeFileSync(`${tmpDir}/foo`, '');
+    await lockfile.lock(`${tmpDir}/foo`, {
+        checkMtimeOwnership: false,
+        update: 1000,
+        stale: 2000,
+        onCompromised: (err) => expect(err).toBeInstanceOf(Error),
+    });
+    sleep(3000);
+    await pDelay(5000);
+}, 16000);
+
+it('should fail to update mtime when forced over the threshold, not first update ', async () => {
+    fs.writeFileSync(`${tmpDir}/foo`, '');
+    await lockfile.lock(`${tmpDir}/foo`, {
+        checkMtimeOwnership: false,
+        update: 1000,
+        stale: 2000,
+        onCompromised: (err) => expect(err).toBeInstanceOf(Error),
+    });
+    setTimeout(() => {
+        sleep(3000);
+    }, 1000);
+    await pDelay(5000);
+}, 16000);

--- a/test/lock.test.js
+++ b/test/lock.test.js
@@ -520,29 +520,3 @@ it('should not fail to update mtime when we are over the threshold but mtime is 
     }, 1000);
     await pDelay(5000);
 }, 16000);
-
-it('should fail to update mtime when forced over the threshold, first update ', async () => {
-    fs.writeFileSync(`${tmpDir}/foo`, '');
-    await lockfile.lock(`${tmpDir}/foo`, {
-        checkMtimeOwnership: false,
-        update: 1000,
-        stale: 2000,
-        onCompromised: (err) => expect(err).toBeInstanceOf(Error),
-    });
-    sleep(3000);
-    await pDelay(5000);
-}, 16000);
-
-it('should fail to update mtime when forced over the threshold, not first update ', async () => {
-    fs.writeFileSync(`${tmpDir}/foo`, '');
-    await lockfile.lock(`${tmpDir}/foo`, {
-        checkMtimeOwnership: false,
-        update: 1000,
-        stale: 2000,
-        onCompromised: (err) => expect(err).toBeInstanceOf(Error),
-    });
-    setTimeout(() => {
-        sleep(3000);
-    }, 1000);
-    await pDelay(5000);
-}, 16000);


### PR DESCRIPTION
now we keep track of the mtime updated by the current process, and if we lose some cycles in the update process but recover and the mtime is still ours we do not mark the lock as compromised

closes #71 

ref:
https://github.com/ipfs/js-ipfs-repo/issues/188#issuecomment-468682971