### PR TITLE
feat: allow second precision in mtime comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Available options:
 - `fs`: A custom fs to use, defaults to `graceful-fs`
 - `onCompromised`: Called if the lock gets compromised, defaults to a function that simply throws the error which will probably cause the process to die
 - `lockfilePath`: Custom lockfile path. e.g.: If you want to lock a directory and create the lock file inside it, you can pass `file` as `<dir path>` and `options.lockfilePath` as `<dir path>/dir.lock`
+- `allowSecondPrecision`: Allows second precision in `mtime` comparison. If using a file system that allows millisecond precision it's best to set this to `false`, defaults to `true`
 
 
 ```js

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -82,6 +82,18 @@ function removeLock(file, options, callback) {
     });
 }
 
+function isEqualDates(d0, d1, options) {
+    if (d0.getTime() === d1.getTime()) {
+        return true;
+    }
+
+    if (!options.allowSecondPrecision) {
+        return false;
+    }
+
+    return Math.trunc(d0.getTime() / 1000) === Math.trunc(d1.getTime() / 1000);
+}
+
 function updateLock(file, options) {
     const lock = locks[file];
 
@@ -111,7 +123,7 @@ function updateLock(file, options) {
                 return updateLock(file, options);
             }
 
-            const isMtimeOurs = lock.mtime.getTime() === stat.mtime.getTime();
+            const isMtimeOurs = isEqualDates(lock.mtime, stat.mtime, options);
 
             if (!isMtimeOurs) {
                 return setLockAsCompromised(
@@ -204,6 +216,7 @@ function lock(file, options, callback) {
     options.stale = Math.max(options.stale || 0, 2000);
     options.update = options.update == null ? options.stale / 2 : options.update || 0;
     options.update = Math.max(Math.min(options.update, options.stale / 2), 1000);
+    options.allowSecondPrecision = options.allowSecondPrecision == null ? true : options.allowSecondPrecision;
 
     // Resolve to a canonical file path
     resolveCanonicalPath(file, options, (err, file) => {


### PR DESCRIPTION
`mtime` precision is file system dependent. Originally `mtime` had second level precision, so the only way to be safe is to assume this by default giving the option to allow ms precision if the user knows their filesystem supports it.

Is this a good idea? Should we detect support instead (e.g. set mtime with `utimes` and read it back)? Or should we consider a different implementation?