### PR TITLE
docs: add reject promise / throws on error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ As you see, the first two are a consequence of bad usage. Technically, it was po
 
 ### .lock(file, [options])
 
-Tries to acquire a lock on `file` or rejects the promise by throwing on error.
+Tries to acquire a lock on `file` or rejects the promise on error.
 
-If the lock succeeds, a `release` function is provided that should be called when you want to release the lock. The `release` function also rejects the promise by throwing on error (e.g. when the lock was already compromised).
+If the lock succeeds, a `release` function is provided that should be called when you want to release the lock. The `release` function also rejects the promise on error (e.g. when the lock was already compromised).
 
 Available options:
 
@@ -105,7 +105,7 @@ lockfile.lock('some/file')
 
 ### .unlock(file, [options])
 
-Releases a previously acquired lock on `file` or rejects the promise by throwing on error.
+Releases a previously acquired lock on `file` or rejects the promise on error.
 
 Whenever possible you should use the `release` function instead (as exemplified above). Still there are cases in which its hard to keep a reference to it around code. In those cases `unlock()` might be handy.
 
@@ -130,7 +130,7 @@ lockfile.lock('some/file')
 
 ### .check(file, [options])
 
-Check if the file is locked and its lockfile is not stale, rejects the promise by throwing on error.
+Check if the file is locked and its lockfile is not stale, rejects the promise on error.
 
 Available options:
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ As you see, the first two are a consequence of bad usage. Technically, it was po
 
 ### .lock(file, [options])
 
-Tries to acquire a lock on `file`.
+Tries to acquire a lock on `file` or rejects the promise by throwing on error.
 
-If the lock succeeds, a `release` function is provided that should be called when you want to release the lock.
+If the lock succeeds, a `release` function is provided that should be called when you want to release the lock. The `release` function also rejects the promise by throwing on error (e.g. when the lock was already compromised).
 
 Available options:
 
@@ -92,6 +92,11 @@ lockfile.lock('some/file')
     // Call the provided release function when you're done,
     // which will also return a promise
     return release();
+})
+.catch((e) => {
+    // either lock could not be acquired
+    // or releasing it failed
+    console.error(e)
 });
 
 // Alternatively, you may use lockfile('some/file') directly.
@@ -100,7 +105,7 @@ lockfile.lock('some/file')
 
 ### .unlock(file, [options])
 
-Releases a previously acquired lock on `file`.
+Releases a previously acquired lock on `file` or rejects the promise by throwing on error.
 
 Whenever possible you should use the `release` function instead (as exemplified above). Still there are cases in which its hard to keep a reference to it around code. In those cases `unlock()` might be handy.
 
@@ -125,7 +130,7 @@ lockfile.lock('some/file')
 
 ### .check(file, [options])
 
-Check if the file is locked and its lockfile is not stale.
+Check if the file is locked and its lockfile is not stale, rejects the promise by throwing on error.
 
 Available options:
 


### PR DESCRIPTION
Resolves #80 

Improve readme by adding clear messages for all functions which can be rejected / throws on error.