### PR TITLE
feat: add TS types and fix node 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.*
 coverage/
 test/tmp/
 test/*.log
+dist

--- a/index.js
+++ b/index.js
@@ -1,32 +1,83 @@
+/* eslint-disable jsdoc/valid-types */
+
 'use strict';
 
 const lockfile = require('./lib/lockfile');
 const { toPromise, toSync, toSyncOptions } = require('./lib/adapter');
 
+/**
+ * @typedef {import("./lib/types").LockOptions} LockOptions
+ * @typedef {import("./lib/types").release} release
+ */
+
+/**
+ * Tries to acquire a lock on file or rejects the promise on error.
+ * If the lock succeeds, a release function is provided that should be called when you want to release the lock. The release function also rejects the promise on error (e.g. When the lock was already compromised).
+ *
+ * @param {string} file - File to acquire lock on.
+ * @param {LockOptions} options - Lock options.
+ * @returns {Promise<release>} Return value.
+ */
 async function lock(file, options) {
     const release = await toPromise(lockfile.lock)(file, options);
 
     return toPromise(release);
 }
 
+/**
+ * Sync version of .lock().
+ *
+ * @param {string} file - File to acquire lock on.
+ * @param {LockOptions} options - Lock options.
+ * @returns { () => void } Returns the release function or throws on error.
+ */
 function lockSync(file, options) {
     const release = toSync(lockfile.lock)(file, toSyncOptions(options));
 
     return toSync(release);
 }
 
+/**
+ * Releases a previously acquired lock on file or rejects the promise on error.
+ * Whenever possible you should use the release function instead (as exemplified above). Still there are cases in which it's hard to keep a reference to it around code. In those cases unlock() might be handy.
+ *
+ * @param {string} file - File to release lock on.
+ * @param {Pick<LockOptions, "realpath" | "fs" | "lockfilePath">} options - Unlock options.
+ * @returns {Promise<void>}
+ */
 function unlock(file, options) {
     return toPromise(lockfile.unlock)(file, options);
 }
 
+/**
+ * Sync version of .lock().
+ *
+ * @param {string} file - File to release lock on.
+ * @param {Pick<LockOptions, "realpath" | "fs" | "lockfilePath">} options - Unlock options.
+ * @returns {void}
+ */
 function unlockSync(file, options) {
     return toSync(lockfile.unlock)(file, toSyncOptions(options));
 }
 
+/**
+ * Check if the file is locked and its lockfile is not stale, rejects the promise on error.
+ *
+ * @param {string} file - File to check if a lock is active.
+ * @param {Pick<LockOptions, "realpath" | "fs" | "lockfilePath" | "stale">} options - Check options.
+ * @returns {Promise<boolean>}
+ */
 function check(file, options) {
     return toPromise(lockfile.check)(file, options);
 }
 
+/**
+ * Check if the file is locked and its lockfile is not stale, rejects the promise on error.
+ *
+ * @param {string} file - File to check if a lock is active.
+ * @param {Pick<LockOptions, "realpath" | "fs" | "lockfilePath" | "stale">} options - Check options.
+ * @returns {boolean}
+ */
 function checkSync(file, options) {
     return toSync(lockfile.check)(file, toSyncOptions(options));
 }

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,17 +1,33 @@
+/* eslint-disable jsdoc/require-returns */
+/* eslint-disable jsdoc/require-param-description */
+/* eslint-disable jsdoc/valid-types */
+
 'use strict';
 
 const fs = require('graceful-fs');
 
+/**
+ * @typedef {import("./types").LockOptions} LockOptions
+ */
+
+/**
+ * Create a Sync FS interface.
+ *
+ * @param {fs} fs - FS module.
+ * @returns {fs}
+ */
 function createSyncFs(fs) {
     const methods = ['mkdir', 'realpath', 'stat', 'rmdir', 'utimes'];
     const newFs = { ...fs };
 
     methods.forEach((method) => {
+        // @ts-ignore
         newFs[method] = (...args) => {
             const callback = args.pop();
             let ret;
 
             try {
+                // @ts-ignore
                 ret = fs[`${method}Sync`](...args);
             } catch (err) {
                 return callback(err);
@@ -26,42 +42,70 @@ function createSyncFs(fs) {
 
 // ----------------------------------------------------------
 
+/**
+ * @template TResult
+ * @param {(file: string, options: LockOptions, cb: (err: Error | undefined | null, value?: TResult) => void) => void} method - Method to promisify.
+ * @returns {(...args: any[]) => Promise<TResult>}
+ */
 function toPromise(method) {
     return (...args) => new Promise((resolve, reject) => {
-        args.push((err, result) => {
+        /**
+         * @param {any} err
+         * @param {any} result
+         */
+        const cb = (err, result) => {
             if (err) {
                 reject(err);
             } else {
                 resolve(result);
             }
-        });
+        };
 
+        args.push(cb);
+
+        // @ts-ignore - keep it generic
         method(...args);
     });
 }
 
+/**
+ * @template TResult
+ * @param {(file: string, options: LockOptions, cb: (err: Error | undefined | null, value?: TResult) => void) => void} method - Method callbackify.
+ * @returns {(...args: any[]) => TResult}
+ */
 function toSync(method) {
     return (...args) => {
         let err;
+        /** @type{TResult} */
         let result;
-
-        args.push((_err, _result) => {
+        /**
+         * @param {any} _err
+         * @param {any} _result
+         */
+        const cb = (_err, _result) => {
             err = _err;
             result = _result;
-        });
+        };
 
+        args.push(cb);
+
+        // @ts-ignore
         method(...args);
 
         if (err) {
             throw err;
         }
 
+        // @ts-ignore
         return result;
     };
 }
 
+/**
+ * @param {LockOptions} options - Options.
+ */
 function toSyncOptions(options) {
-    // Shallow clone options because we are oging to mutate them
+    // Shallow clone options because we are going to mutate them
     options = { ...options };
 
     // Transform fs to use the sync methods instead
@@ -70,7 +114,7 @@ function toSyncOptions(options) {
     // Retries are not allowed because it requires the flow to be sync
     if (
         (typeof options.retries === 'number' && options.retries > 0) ||
-        (options.retries && typeof options.retries.retries === 'number' && options.retries.retries > 0)
+        (typeof options.retries === 'object' && typeof options.retries.retries === 'number' && options.retries.retries > 0)
     ) {
         throw Object.assign(new Error('Cannot use retries with the sync api'), { code: 'ESYNC' });
     }

--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -1,3 +1,7 @@
+/* eslint-disable jsdoc/require-returns */
+/* eslint-disable jsdoc/require-param-description */
+/* eslint-disable jsdoc/valid-types */
+
 'use strict';
 
 const path = require('path');
@@ -5,13 +9,29 @@ const fs = require('graceful-fs');
 const retry = require('retry');
 const onExit = require('signal-exit');
 const mtimePrecision = require('./mtime-precision');
+/**
+ * @typedef {import("./types").LockOptions} LockOptions
+ * @typedef {import("./types").Lock} Lock
+ * @typedef {import("./types").InternalLockOptions} InternalLockOptions
+ * @typedef {Parameters<import("./mtime-precision")["probe"]>[2]} ProbeCallback
+ */
 
+/** @type {Record<string, Lock>} */
 const locks = {};
 
+/**
+ * @param {string} file - Lock file.
+ * @param {LockOptions} options - Options.
+ */
 function getLockFile(file, options) {
     return options.lockfilePath || `${file}.lock`;
 }
 
+/**
+ * @param {string} file
+ * @param {InternalLockOptions} options
+ * @param {(err: Error|null, resolvedPath: string) => void} callback
+ */
 function resolveCanonicalPath(file, options, callback) {
     if (!options.realpath) {
         return callback(null, path.resolve(file));
@@ -22,6 +42,11 @@ function resolveCanonicalPath(file, options, callback) {
     options.fs.realpath(file, callback);
 }
 
+/**
+ * @param {string} file
+ * @param {InternalLockOptions} options
+ * @param {ProbeCallback} callback
+ */
 function acquireLock(file, options, callback) {
     const lockfilePath = getLockFile(file, options);
 
@@ -39,7 +64,7 @@ function acquireLock(file, options, callback) {
                     return callback(err);
                 }
 
-                callback(null, mtime, mtimePrecision);
+                callback(undefined, mtime, mtimePrecision);
             });
         }
 
@@ -81,10 +106,19 @@ function acquireLock(file, options, callback) {
     });
 }
 
+/**
+ * @param {fs.Stats} stat
+ * @param {InternalLockOptions} options
+ */
 function isLockStale(stat, options) {
     return stat.mtime.getTime() < Date.now() - options.stale;
 }
 
+/**
+ * @param {string} file
+ * @param {InternalLockOptions} options
+ * @param {(err?: Error) => void} callback
+ */
 function removeLock(file, options, callback) {
     // Remove lockfile, ignoring ENOENT errors
     options.fs.rmdir(getLockFile(file, options), (err) => {
@@ -96,6 +130,10 @@ function removeLock(file, options, callback) {
     });
 }
 
+/**
+ * @param {string} file
+ * @param {InternalLockOptions} options
+ */
 function updateLock(file, options) {
     const lock = locks[file];
 
@@ -182,6 +220,11 @@ function updateLock(file, options) {
     }
 }
 
+/**
+ * @param {string} file
+ * @param {Lock} lock
+ * @param {Error & { code: string; }} err
+ */
 function setLockAsCompromised(file, lock, err) {
     // Signal the lock has been released
     lock.released = true;
@@ -202,6 +245,11 @@ function setLockAsCompromised(file, lock, err) {
 
 // ----------------------------------------------------------
 
+/**
+ * @param {string} file
+ * @param {LockOptions} options
+ * @param {(err: Error | null, release?: ((releasedCallback: any) => void)) => void} callback
+ */
 function lock(file, options, callback) {
     /* istanbul ignore next */
     options = {
@@ -219,18 +267,20 @@ function lock(file, options, callback) {
     options.stale = Math.max(options.stale || 0, 2000);
     options.update = options.update == null ? options.stale / 2 : options.update || 0;
     options.update = Math.max(Math.min(options.update, options.stale / 2), 1000);
+    const opts = /** @type {InternalLockOptions} */(options);
 
     // Resolve to a canonical file path
-    resolveCanonicalPath(file, options, (err, file) => {
+    resolveCanonicalPath(file, opts, (err, file) => {
         if (err) {
             return callback(err);
         }
 
         // Attempt to acquire the lock
-        const operation = retry.operation(options.retries);
+        // @ts-ignore - Retry should be able to handle number
+        const operation = retry.operation(opts.retries);
 
         operation.attempt(() => {
-            acquireLock(file, options, (err, mtime, mtimePrecision) => {
+            acquireLock(file, opts, (err, mtime, mtimePrecision) => {
                 if (operation.retry(err)) {
                     return;
                 }
@@ -240,16 +290,19 @@ function lock(file, options, callback) {
                 }
 
                 // We now own the lock
+                /** @type {Lock} */
                 const lock = locks[file] = {
-                    lockfilePath: getLockFile(file, options),
+                    lockfilePath: getLockFile(file, opts),
+                    // @ts-ignore
                     mtime,
+                    // @ts-ignore
                     mtimePrecision,
-                    options,
+                    options: opts,
                     lastUpdate: Date.now(),
                 };
 
                 // We must keep the lock fresh to avoid staleness
-                updateLock(file, options);
+                updateLock(file, opts);
 
                 callback(null, (releasedCallback) => {
                     if (lock.released) {
@@ -258,22 +311,28 @@ function lock(file, options, callback) {
                     }
 
                     // Not necessary to use realpath twice when unlocking
-                    unlock(file, { ...options, realpath: false }, releasedCallback);
+                    unlock(file, { ...opts, realpath: false }, releasedCallback);
                 });
             });
         });
     });
 }
 
+/**
+ * @param {string} file
+ * @param {LockOptions} options
+ * @param {(err?: Error)=> void} callback
+ */
 function unlock(file, options, callback) {
     options = {
         fs,
         realpath: true,
         ...options,
     };
+    const opts = /** @type {InternalLockOptions} */(options);
 
     // Resolve to a canonical file path
-    resolveCanonicalPath(file, options, (err, file) => {
+    resolveCanonicalPath(file, opts, (err, file) => {
         if (err) {
             return callback(err);
         }
@@ -289,10 +348,15 @@ function unlock(file, options, callback) {
         lock.released = true; // Signal the lock has been released
         delete locks[file]; // Delete from locks
 
-        removeLock(file, options, callback);
+        removeLock(file, opts, callback);
     });
 }
 
+/**
+ * @param {string} file
+ * @param {LockOptions} options
+ * @param {(err: Error | undefined, isStale?: boolean) => void} callback
+ */
 function check(file, options, callback) {
     options = {
         stale: 10000,
@@ -302,22 +366,23 @@ function check(file, options, callback) {
     };
 
     options.stale = Math.max(options.stale || 0, 2000);
+    const opts = /** @type {InternalLockOptions} */(options);
 
     // Resolve to a canonical file path
-    resolveCanonicalPath(file, options, (err, file) => {
+    resolveCanonicalPath(file, opts, (err, file) => {
         if (err) {
             return callback(err);
         }
 
         // Check if lockfile exists
-        options.fs.stat(getLockFile(file, options), (err, stat) => {
+        opts.fs.stat(getLockFile(file, opts), (err, stat) => {
             if (err) {
                 // If does not exist, file is not locked. Otherwise, callback with error
-                return err.code === 'ENOENT' ? callback(null, false) : callback(err);
+                return err.code === 'ENOENT' ? callback(undefined, false) : callback(err);
             }
 
             // Otherwise, check if lock is stale by analyzing the file mtime
-            return callback(null, !isLockStale(stat, options));
+            return callback(undefined, !isLockStale(stat, opts));
         });
     });
 }

--- a/lib/mtime-precision.js
+++ b/lib/mtime-precision.js
@@ -1,8 +1,25 @@
+/* eslint-disable jsdoc/require-returns */
+/* eslint-disable jsdoc/require-param-description */
+/* eslint-disable jsdoc/valid-types */
+
 'use strict';
 
 const cacheSymbol = Symbol();
 
+/**
+ * @typedef {import("./types").LockOptions} LockOptions
+ * @typedef {import("graceful-fs")} fs
+ * @typedef {import("graceful-fs").Stats} Stats
+ */
+
+/**
+ * @param {any} file
+ * @param {fs} fs
+ * @param {(err: Error | undefined, mtime?: Date, cachedPrecision?: "s" | "ms") => void} callback
+ */
 function probe(file, fs, callback) {
+    /** @type {"s" | "ms"} */
+    // @ts-ignore
     const cachedPrecision = fs[cacheSymbol];
 
     if (cachedPrecision) {
@@ -12,7 +29,7 @@ function probe(file, fs, callback) {
                 return callback(err);
             }
 
-            callback(null, stat.mtime, cachedPrecision);
+            callback(undefined, stat.mtime, cachedPrecision);
         });
     }
 
@@ -36,11 +53,14 @@ function probe(file, fs, callback) {
             // Cache the precision in a non-enumerable way
             Object.defineProperty(fs, cacheSymbol, { value: precision });
 
-            callback(null, stat.mtime, precision);
+            callback(undefined, stat.mtime, precision);
         });
     });
 }
 
+/**
+ * @param {"s" | "ms"} precision
+ */
 function getMtime(precision) {
     let now = Date.now();
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,65 @@
+import type {OperationOptions} from 'retry'
+import type fs from 'graceful-fs'
+
+interface LockOptions {
+  /**
+   * Duration in milliseconds in which the lock is considered stale, defaults to 10000 (minimum value is 5000)
+   */
+  stale?: number
+  /**
+   * The interval in milliseconds in which the lockfile's mtime will be updated, defaults to stale/2 (minimum value is 1000, maximum value is stale/2)
+   */
+  update?: number | null
+  /**
+   * The number of retries or a retry options object, defaults to 0
+   */
+  retries?: number | OperationOptions
+  /**
+   * A custom fs to use, defaults to `graceful-fs`
+   */
+  fs?: typeof fs
+  /**
+   * Resolve symlinks using realpath, defaults to true (note that if true, the file must exist previously)
+   */
+  realpath?: boolean
+  /**
+   * Called if the lock gets compromised, defaults to a function that simply throws the error which will probably cause the process to die
+   */
+  onCompromised?: (err: Error) => void
+  /**
+   * Custom lockfile path. e.g.: If you want to lock a directory and create the lock file inside it, you can pass file as <dir path> and options.lockfilePath as <dir path>/dir.lock
+   */
+  lockfilePath?: string
+}
+
+/**
+ * Internal lock options to be used after the defaults are merged
+ */
+interface InternalLockOptions {
+    stale: number
+    update: number
+    retries: number | OperationOptions
+    fs: typeof fs
+    realpath: boolean
+    onCompromised: (err: Error) => void
+    lockfilePath?: string
+}
+
+interface Lock {
+    lockfilePath: string
+    mtime: Date
+    mtimePrecision: "s" | "ms"
+    options: InternalLockOptions,
+    lastUpdate: number,
+    updateTimeout?: NodeJS.Timeout | null,
+    updateDelay?: number | null,
+    released?: boolean
+}
+
+export declare function release (): Promise<void>
+
+export type {
+  Lock,
+  LockOptions,
+  InternalLockOptions
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -728,6 +728,15 @@
         }
       }
     },
+    "@types/graceful-fs": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+      "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
@@ -738,6 +747,18 @@
       "version": "11.11.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.2.tgz",
       "integrity": "sha512-iEaHiDNkHv4Jrm9O5T37OYEUwjJesiyt6ZlhLFK0sbo4CLD0jyCOB4Pc2F9iD3MbW2397SLNxZKdDGntGaBjQQ==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "@types/signal-exit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/signal-exit/-/signal-exit-3.0.0.tgz",
+      "integrity": "sha512-MaJ+16SOXz0Z27EMf3d88+B6UDglq1sn140a+5X/ROLkIcEfRq0CPg+1B2efF1GXQn4n+aKH4ti2hHG4Ya+Dzg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -8077,6 +8098,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3347,9 +3347,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "growly": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
   },
   "license": "MIT",
   "main": "index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
   "scripts": {
+    "prepare": "tsc",
     "lint": "eslint .",
-    "test": "jest --env node --coverage --runInBand",
+    "test": "tsc && jest --env node --coverage --runInBand",
     "prerelease": "npm t && npm run lint",
     "release": "standard-version",
     "postrelease": "git push --follow-tags origin HEAD && npm publish"
@@ -54,6 +57,9 @@
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.1",
     "@segment/clear-timeouts": "^2.0.0",
+    "@types/graceful-fs": "^4.1.4",
+    "@types/retry": "^0.12.0",
+    "@types/signal-exit": "^3.0.0",
     "delay": "^4.1.0",
     "eslint": "^5.3.0",
     "eslint-config-moxy": "^7.1.0",
@@ -66,6 +72,7 @@
     "rimraf": "^2.6.2",
     "stable": "^0.1.8",
     "standard-version": "^5.0.0",
-    "thread-sleep": "^2.1.0"
+    "thread-sleep": "^2.1.0",
+    "typescript": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "dependencies": {
-    "graceful-fs": "^4.1.11",
+    "graceful-fs": "^4.2.4",
     "retry": "^0.12.0",
     "signal-exit": "^3.0.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        // project options
+        "outDir": "dist",
+        "allowJs": true,
+        "checkJs": true,
+        "target": "ES2019",
+        "lib": ["ES2019", "ES2020.Promise", "ES2020.String", "ES2020.BigInt", "DOM", "DOM.Iterable"],
+        "noEmit": false,
+        "noEmitOnError": true,
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "declarationMap": true,
+        "incremental": true,
+        "composite": true,
+        "isolatedModules": true,
+        "removeComments": false,
+        // module resolution
+        "esModuleInterop": true,
+        "moduleResolution": "node",
+        // linter checks
+        "noImplicitReturns": false,
+        "noFallthroughCasesInSwitch": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": false,
+        // advanced
+        "importsNotUsedAsValues": "error",
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "stripInternal": true,
+        "resolveJsonModule": true
+    },
+    "include": [
+        "index.js",
+        "lib"
+    ]
+}


### PR DESCRIPTION
This PR does:
- Upgrades graceful-fs to a version that works in node 14
- Add typescript types using JSDocs

Running `npm test` checks the types and generates `.d.ts` to the dist folder, which will be publish to provide type declarations.

/cc @achingbrain

TODO:

- [ ] remove prepare script