### PR TITLE
fix: check if onCompromised function is defined

### DIFF
--- a/lib/lockfile.js
+++ b/lib/lockfile.js
@@ -197,7 +197,9 @@ function setLockAsCompromised(file, lock, err) {
         delete locks[file];
     }
 
-    lock.options.onCompromised(err);
+    if(lock.options.onCompromised){
+        lock.options.onCompromised(err);
+    }
 }
 
 // ----------------------------------------------------------


### PR DESCRIPTION
This PR contains a quick fix: checking whether the onCompromised option has been defined or not before running the function.